### PR TITLE
sepolicy: core_data_file_type

### DIFF
--- a/vendor/common/file.te
+++ b/vendor/common/file.te
@@ -28,7 +28,7 @@ type qdcmsocket_socket, file_type;
 
 # Define cnd socket and data file type
 type cnd_socket, file_type, mlstrustedobject;
-type cnd_data_file, file_type, data_file_type;
+type cnd_data_file, file_type, data_file_type, core_data_file_type;
 type chre_socket, file_type;
 
 # Define dpmd data file type
@@ -203,7 +203,7 @@ type hbtp_kernel_sysfs, fs_type, sysfs_type;
 type persist_usf_file, file_type, vendor_persist_type;
 
 #qfp-daemon
-type qfp-daemon_data_file, file_type, data_file_type;
+type qfp-daemon_data_file, file_type, data_file_type, core_data_file_type;
 type persist_qti_fp_file, file_type, vendor_persist_type;
 
 # imshelper_app file types


### PR DESCRIPTION
The following types on /data/ must be associated with the "core_data_file_type" attribute: cnd_data_file qfp-daemon_data_file